### PR TITLE
Skip build wokrflow on master and tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - build:
+        filters:
+          branches:
+            ignore: master
   build-master:
     jobs:
       - build:


### PR DESCRIPTION
To save CircleCI credits﻿.

We only want to run build workflow on non-master branches (PRs), build-master only on master, and build-tags only on tag pushes.
